### PR TITLE
Normalize decoder curves before augmentation

### DIFF
--- a/Modules/istftnet.py
+++ b/Modules/istftnet.py
@@ -497,20 +497,64 @@ class Decoder(nn.Module):
                                    upsample_kernel_sizes, gen_istft_n_fft, gen_istft_hop_size)
         
     def forward(self, asr, F0_curve, N, s):
+        batch = asr.size(0)
+        target_len = asr.size(-1)
+
+        def _normalize_curve(curve, name):
+            if not torch.is_tensor(curve):
+                curve = torch.as_tensor(curve, device=asr.device, dtype=asr.dtype)
+            else:
+                curve = curve.to(device=asr.device, dtype=asr.dtype)
+
+            if curve.dim() == 0:
+                curve = curve.view(1, 1)
+            if curve.dim() == 1:
+                curve = curve.unsqueeze(0)
+            elif curve.dim() == 2 and curve.size(0) != batch and curve.size(1) == batch:
+                curve = curve.transpose(0, 1)
+            elif curve.dim() > 2:
+                curve = curve.reshape(curve.size(0), -1)
+                if curve.size(0) != batch and curve.size(1) == batch:
+                    curve = curve.transpose(0, 1)
+
+            if curve.size(0) == 1 and batch > 1:
+                curve = curve.expand(batch, curve.size(1))
+            elif curve.size(0) != batch:
+                total = curve.numel()
+                if total % batch == 0:
+                    curve = curve.reshape(batch, total // batch)
+                else:
+                    raise ValueError(f"Unexpected {name} shape {tuple(curve.shape)} (cannot match batch {batch})")
+
+            if curve.size(1) != target_len:
+                curve = F.interpolate(
+                    curve.unsqueeze(1),
+                    size=target_len,
+                    mode="linear",
+                    align_corners=False,
+                ).squeeze(1)
+
+            return curve.contiguous()
+
+        F0_curve = _normalize_curve(F0_curve, "F0_curve")
+        N = _normalize_curve(N, "N")
+
         if self.training:
             downlist = [0, 3, 7]
             F0_down = downlist[random.randint(0, 2)]
             downlist = [0, 3, 7, 15]
             N_down = downlist[random.randint(0, 3)]
             if F0_down:
-                F0_curve = nn.functional.conv1d(F0_curve.unsqueeze(1), torch.ones(1, 1, F0_down).to('cuda'), padding=F0_down//2).squeeze(1) / F0_down
+                kernel = torch.ones(1, 1, F0_down, device=F0_curve.device, dtype=F0_curve.dtype)
+                F0_curve = nn.functional.conv1d(F0_curve.unsqueeze(1), kernel, padding=F0_down // 2).squeeze(1) / F0_down
             if N_down:
-                N = nn.functional.conv1d(N.unsqueeze(1), torch.ones(1, 1, N_down).to('cuda'), padding=N_down//2).squeeze(1)  / N_down
+                kernel = torch.ones(1, 1, N_down, device=N.device, dtype=N.dtype)
+                N = nn.functional.conv1d(N.unsqueeze(1), kernel, padding=N_down // 2).squeeze(1) / N_down
 
-        
         F0 = self.F0_conv(F0_curve.unsqueeze(1))
+
         N = self.N_conv(N.unsqueeze(1))
-        
+
         x = torch.cat([asr, F0, N], axis=1)
         x = self.encode(x, s)
         

--- a/Modules/istftnet.py
+++ b/Modules/istftnet.py
@@ -508,23 +508,32 @@ class Decoder(nn.Module):
 
             if curve.dim() == 0:
                 curve = curve.view(1, 1)
-            if curve.dim() == 1:
-                curve = curve.unsqueeze(0)
-            elif curve.dim() == 2 and curve.size(0) != batch and curve.size(1) == batch:
-                curve = curve.transpose(0, 1)
+            elif curve.dim() == 1:
+                curve = curve.view(1, -1)
             elif curve.dim() > 2:
                 curve = curve.reshape(curve.size(0), -1)
-                if curve.size(0) != batch and curve.size(1) == batch:
+
+            if curve.dim() == 2 and curve.size(0) != batch and curve.size(1) == batch:
+                curve = curve.transpose(0, 1)
+
+            if curve.dim() != 2:
+                curve = curve.reshape(1, -1)
+
+            if curve.size(0) != batch:
+                if curve.numel() == target_len:
+                    curve = curve.view(1, target_len)
+                elif curve.numel() % target_len == 0:
+                    curve = curve.view(-1, target_len)
+                elif curve.size(0) == 1:
+                    curve = curve.view(1, -1)
+                elif curve.size(1) == batch:
                     curve = curve.transpose(0, 1)
 
             if curve.size(0) == 1 and batch > 1:
                 curve = curve.expand(batch, curve.size(1))
-            elif curve.size(0) != batch:
-                total = curve.numel()
-                if total % batch == 0:
-                    curve = curve.reshape(batch, total // batch)
-                else:
-                    raise ValueError(f"Unexpected {name} shape {tuple(curve.shape)} (cannot match batch {batch})")
+
+            if curve.size(0) != batch:
+                raise ValueError(f"Unexpected {name} shape {tuple(curve.shape)} (cannot match batch {batch})")
 
             if curve.size(1) != target_len:
                 curve = F.interpolate(


### PR DESCRIPTION
## Summary
- normalize pitch and noise tensors to the decoder batch/time dimensions before any optional augmentation
- run optional smoothing with device-appropriate kernels and reuse the normalized curves for both generator calls

## Testing
- python -m compileall Modules/hifigan.py Modules/istftnet.py

------
https://chatgpt.com/codex/tasks/task_e_68dfaada3e208320a2d4c771ece18c2c